### PR TITLE
[TDO-209] Add security audit Travis build stage; fix dependency issue (roave/better-reflection) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
 - "./vendor/bin/phpstan analyse"
 - php vendor/bin/phpunit
 - "./vendor/bin/phpcs"
+- "./vendor/bin/security-checker security:check"
 after_success:
 - "php -d memory_limit=1000m ./vendor/bin/apigen generate src --destination docs"
 addons:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"phpstan/phpstan": "^0.11.0",
 		"phpstan/phpstan-phpunit": "^0.11.0",
 		"apigen/apigen": "dev-master#85290e8",
-		"roave/better-reflection": "dev-master#ce9d784"
+		"roave/better-reflection": "3.3.0 as dev-master",
+		"sensiolabs/security-checker": "^6.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
* Add sensiolabs/security-checker package to Composer dependencies
* Run security-checker during Travis build
* Fix issue with apigen/apigen's dependency on roave/better-reflection (cannot find commit)

apigen/apigen requires roave/better-reflection at "dev-master#c87d856". Composer was unable to find this commit, or any commit for dev-master--possibly because the repo no longer has a 'master' branch. `"roave/better-reflection": "3.3.0 as dev-master"` aliases the last branch compatible with PHP 7.1 with dev-master, so that apigen/apigen can use that to find the particular commit of BetterReflection that it requires. An alternative would be to fork roave/better-reflection or apigen/apigen.